### PR TITLE
Reduce force power off from 12s to 4s

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "hwinit/cluster.h"
 #include "hwinit/clock.h"
 #include "hwinit/util.h"
+#include "hwinit/max7762x.h"
 #include "rcm_usb.h"
 #include "usb_output.h"
 #include "storage.h"
@@ -413,6 +414,7 @@ int main(void)
     u32* lfb_base;    
 
     config_hw();
+    max77620_send_byte(MAX77620_REG_ONOFFCNFG1, 0x48); // Set forced power off via Power button to 4s
     display_enable_backlight(false);
     display_init();
 


### PR DESCRIPTION
Useful when using mass storage features frequently.

It's possible to make that behavior better by adding it to ini though. And reduce the delay by case. Not included in this pr though.

Edit
Want me to make it case by case by ini config?