### PR TITLE
Include algorithm.h

### DIFF
--- a/tools/RelPath.h
+++ b/tools/RelPath.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/filesystem.hpp>
+#include <algorithm>
 
 std::string GetRelativePath(const char* inputFilename, const char* outputFilename)
 {


### PR DESCRIPTION
After I set up boost, Visual Studio complained about std::replace(). I found that it's fixed if you include `algorithm.h`.